### PR TITLE
Add JUnit Jupiter unit tests for PGDBConn and OracleSwap

### DIFF
--- a/OracleSwap/src/test/java/com/hoffnungland/db/corner/oracleswap/AppTest.java
+++ b/OracleSwap/src/test/java/com/hoffnungland/db/corner/oracleswap/AppTest.java
@@ -1,0 +1,13 @@
+package com.hoffnungland.db.corner.oracleswap;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+class AppTest {
+
+    @Test
+    void mainHandlesMissingArgumentsWithoutThrowing() {
+        assertDoesNotThrow(() -> App.main(new String[0]));
+    }
+}

--- a/PGDBConn/src/test/java/com/hoffnungland/db/corner/pgdbconn/AppTest.java
+++ b/PGDBConn/src/test/java/com/hoffnungland/db/corner/pgdbconn/AppTest.java
@@ -1,0 +1,27 @@
+package com.hoffnungland.db.corner.pgdbconn;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+class AppTest {
+
+    @Test
+    void mainPrintsHelloWorld() {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+
+        try {
+            System.setOut(new PrintStream(outBuffer, true, StandardCharsets.UTF_8));
+            App.main(new String[0]);
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        assertEquals("Hello World!" + System.lineSeparator(), outBuffer.toString(StandardCharsets.UTF_8));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
       <scope>test</scope>
   </dependency>
   <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>6.0.3</version>
+      <scope>test</scope>
+  </dependency>
+  <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>


### PR DESCRIPTION
### Motivation
- Provide lightweight JUnit Jupiter smoke tests for the two app modules so basic behavior is validated by CI. 
- Ensure JUnit Jupiter tests are discoverable by the Surefire provider by adding the engine dependency to the parent POM.

### Description
- Added a JUnit Jupiter test `PGDBConn/src/test/java/com/hoffnungland/db/corner/pgdbconn/AppTest.java` that captures `System.out` and asserts `App.main` prints `Hello World!`.
- Added a JUnit Jupiter test `OracleSwap/src/test/java/com/hoffnungland/db/corner/oracleswap/AppTest.java` that asserts `App.main` does not throw when called with no arguments.
- Updated the parent `pom.xml` to include `junit-jupiter-engine` alongside the existing `junit-jupiter-api` test dependency so Jupiter tests are runnable by Surefire.

### Testing
- Ran `mvn -pl PGDBConn,OracleSwap -am test -DskipITs` to execute the new tests; the run failed during environment dependency resolution so the tests could not be executed to completion.
- Failure reason: Maven plugin resolution error for `maven-jarsigner-plugin` (HTTP 403 from Maven Central), preventing the build in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b7e25a00832e8240f88e78549b05)